### PR TITLE
Fixes autocompleting after suggestion selected

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,8 @@
 'use babel';
 
 // These only match prefixes
-const REQUIRE_REGEX = /require\(["']([^"']+)/;
-const ES6_REGEX = /(?:^import .*?|^}) from ["']([^"';]+)/;
+const REQUIRE_REGEX = /require\(["']([^"']+)$/;
+const ES6_REGEX = /(?:^import .*?|^}) from ["']([^"']+)$/;
 
 export function capturedDependency(prefix, importTypes) {
     let results = null;

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -16,13 +16,25 @@ describe('Utils', function() {
         const defaultPackageName = 'package-a_x';
 
         it('handles default import', function() {
-            const statement = `import x_a from "${defaultPackageName}"`;
+            const statement = `import x_a from "${defaultPackageName}`;
 
             expectCorrectMatches(statement, defaultPackageName);
         });
 
+        it('rejects when cursor is after "', function() {
+            let statement = `import x_a from "${defaultPackageName}"`;
+
+            expectCorrectMatches(statement, null);
+
+            statement = `require('${defaultPackageName}'`
+            expectCorrectMatches(statement, null);
+
+            statement += ')';
+            expectCorrectMatches(statement, null);
+        });
+
         it('handles require', function() {
-            const statement = `require('${defaultPackageName}')`;
+            const statement = `require('${defaultPackageName}`;
 
             expectCorrectMatches(statement, defaultPackageName);
         });
@@ -36,10 +48,8 @@ describe('Utils', function() {
                 './stuff/blah'
             ].forEach(packageName => {
                 [
-                    `import x from "${packageName}"`,
-                    // no closing quotation mark
                     `import x from "${packageName}`,
-                    `import x from '${packageName}'`
+                    `import x from '${packageName}`
                 ].forEach(importStatement => {
                     expectCorrectMatches(importStatement, packageName);
                 });
@@ -47,32 +57,32 @@ describe('Utils', function() {
         });
 
         it(`handles 'as' imports`, function() {
-            let statement = `import * as x from '${defaultPackageName}'`;
+            let statement = `import * as x from '${defaultPackageName}`;
 
             expectCorrectMatches(statement, defaultPackageName);
 
-            statement = `import {x_a as someFunc} from '${defaultPackageName}'`;
+            statement = `import {x_a as someFunc} from '${defaultPackageName}`;
             expectCorrectMatches(statement, defaultPackageName);
         });
 
         it('handles destructuring import', function() {
-            const statement = `import {x_a} from "${defaultPackageName}"`;
+            const statement = `import {x_a} from "${defaultPackageName}`;
 
             expectCorrectMatches(statement, defaultPackageName);
         });
 
         it('handles inlined multi imports', function() {
-            let statement = `import def, {x_a} from "${defaultPackageName}"`;
+            let statement = `import def, {x_a} from "${defaultPackageName}`;
 
             expectCorrectMatches(statement, defaultPackageName);
 
-            statement = `import {x_a, x_b} from "${defaultPackageName}"`;
+            statement = `import {x_a, x_b} from "${defaultPackageName}`;
             expectCorrectMatches(statement, defaultPackageName);
         });
 
         it('handles multiline import statement', function() {
             // Regex is only meant for prefix so this only tests against last line of import statement
-            const importStatement = `} from "${defaultPackageName}"`;
+            const importStatement = `} from "${defaultPackageName}`;
 
             expectCorrectMatches(importStatement, defaultPackageName);
         });


### PR DESCRIPTION
Previously, having the cursor after the last quotation mark would still trigger the suggestions list. This was caused by the prefix regex not properly checking the end boundary of the prefix.