### PR TITLE
Watch settings and update search lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,5 @@ New Fuzzy matching (disabled by default)
 ![](https://raw.githubusercontent.com/DanielGarcia-Carrillo/autocomplete-js-import/master/misc/fuzzy-matching.gif)
 
 # TODO / Known Issues
-* Changing settings doesn't do anything until atom restart
 * Fuzzy pattern matching doesn't work with files added/removed after project is added
 * Attempting to fuzzy search with slashes or periods inserts suggestion incorrectly

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,18 +36,29 @@ function parsePackageJSON(file, projectDeps, {suggestDev, suggestProd}) {
     }
 }
 
+const PACKAGE_NAME = 'autocomplete-js-import';
+
 export default {
     config: settings,
 
-    filesMap: Object.create(null),
+    filesMap: new Map(),
     projectDeps: new ProjectDeps(),
 
     _fileWatchers: [],
     _pathListeners: [],
+    _settingsObservers: [],
 
     activate() {
-        const settings = atom.config.get('autocomplete-js-import');
+        const settings = atom.config.get(PACKAGE_NAME);
         const projectPaths = atom.project.getPaths();
+
+        this._settingsObservers.push(...['hiddenFiles', 'fuzzy', 'projectDependencies'].map(setting =>
+            atom.config.onDidChange(`${PACKAGE_NAME}.${setting}`, () => {
+                // Just wipe everything and start fresh, relatively expensive but effective
+                this.deactivate();
+                this.activate();
+            })
+        ));
 
         if (settings.fuzzy.enabled) {
             const options = {
@@ -60,7 +71,7 @@ export default {
             this._buildProjectFilesList(projectPaths, options);
 
             this._pathListeners.push(atom.project.onDidChangePaths(paths => {
-                const newPaths = paths.filter(p => !this.filesMap[p]);
+                const newPaths = paths.filter(p => !this.filesMap.has(p));
 
                 this._buildProjectFilesList(newPaths, options);
             }));
@@ -79,9 +90,17 @@ export default {
 
     deactivate() {
         this._pathListeners.forEach(listener => listener.dispose());
+        this._pathListeners.length = 0;
+
         this._fileWatchers.forEach(watcher => watcher.close());
-        this.filesMap = null;
-        this.projectDeps = null;
+        this._fileWatchers.length = 0;
+
+        this._settingsObservers.forEach(observer => observer.dispose());
+        this._settingsObservers.length = 0;
+
+        // In case of settings change, these references must stay intact for the provide method below to work
+        this.filesMap.clear();
+        this.projectDeps.clear();
     },
 
     provide() {
@@ -108,7 +127,7 @@ export default {
             globPattern += '/**' + fileTypeMatcher + '}';
 
             glob(globPattern, {dot: showHidden, nodir: true}, (err, childPaths) => {
-                this.filesMap[p] = childPaths.map(child => path.relative(p, child));
+                this.filesMap.set(p, childPaths.map(child => path.relative(p, child)));
             });
         });
     },

--- a/lib/project-deps.js
+++ b/lib/project-deps.js
@@ -9,6 +9,10 @@ export default class ProjectDeps {
         this._deps = Object.create(null);
     }
 
+    clear() {
+        this._deps = Object.create(null);
+    }
+
     set(rootPath, deps) {
         this._deps[rootPath] = deps;
     }
@@ -19,7 +23,7 @@ export default class ProjectDeps {
 
     search(currPath, keyword) {
         const rootPaths = Object.keys(this._deps);
-        let pathDeps;
+        let pathDeps = [];
 
         for (let i = 0; i < rootPaths.length; i++) {
             // for the current path to be a child of root, it must start with rootpath
@@ -27,10 +31,6 @@ export default class ProjectDeps {
                 pathDeps = this._deps[rootPaths[i]];
                 break;
             }
-        }
-
-        if (!pathDeps.length) {
-            return [];
         }
 
         return pathDeps.filter(d => startsWith(d, keyword));

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -120,11 +120,11 @@ export default class ImportCompletionProvider {
             return results;
         }
 
-        const targetFileList = this.filesMap[containingRoot.path];
+        const targetFileList = this.filesMap.get(containingRoot.path);
 
         for (let i = 0; i < targetFileList.length && results.length < max; i++) {
             if (Fuzzy.test(stringPattern, targetFileList[i])) {
-                const rootRelativePath = this.filesMap[containingRoot.path][i];
+                const rootRelativePath = targetFileList[i];
                 let currFileRelativePath = path.relative(
                     getParentDir(editorPath),
                     containingRoot.path + '/' + rootRelativePath

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,15 @@ export function endsWith(base, keyword) {
     return keywordRegex.test(base);
 }
 
+/**
+ * Returns a function that returns the logical negation of the given function's output
+ */
+export function not(func) {
+    return function() {
+        return !func(...arguments);
+    };
+}
+
 // Used to check if a given string matches the constraints of NPM naming
 // Algo basically taken from https://docs.npmjs.com/files/package.json
 export function matchesNPMNaming(prefix) {


### PR DESCRIPTION
Also fixed a bug where fuzzy didn't work without project dependency settings enabled.
More properly clean out listeners now.
Fixed a regression where relative file checks didn't work because I stupidly removed the `#not` function, which was still in use.