### PR TITLE
Better globbing for fuzzy search

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,25 +109,21 @@ export default {
 
     _buildProjectFilesList(projectPaths, {excludedDirs, fileTypes, showHidden}) {
         projectPaths.forEach(p => {
-            let fileTypeMatcher = '/*';
 
-            // TODO: put this filematching logic into a utility
-            if (fileTypes.length && fileTypes[0] !== '*') {
-                fileTypeMatcher += `.{${fileTypes.join(',')}}`
-            }
+            // Join together our desired file extensions, like "ts,js,jsx,json"
+            // if necessary. Glob will fail if you give it just one extension
+            // like "js" so handle that case separately.
+            const fileTypeSet = fileTypes.length === 1 ? fileTypes[0] : `{${fileTypes.join(',')}}`;
+            
+            // Create our base glob like "/path/to/project/**/*.{ts,js,jsx,json}"
+            const globPattern = `${p}/**/*.${fileTypeSet}`;
+            
+            // Use the ignore option to exclude the given directories anywhere
+            // including a subpath.
+            const ignore = excludedDirs.map(dir => `${p}/**/${dir}/**`); // like ["/path/to/project/**/node_modules/**", etc.]
 
-            // the double matching is done to check the top level dir :-/
-            let globPattern = '{' + p + fileTypeMatcher + ',' + p;
-
-            // TODO: make this work with non top level dirs
-            if (excludedDirs.length) {
-                globPattern += `/!(${excludedDirs.join('|')})`;
-            }
-
-            globPattern += '/**' + fileTypeMatcher + '}';
-
-            glob(globPattern, {dot: showHidden, nodir: true}, (err, childPaths) => {
-                this.filesMap.set(p, childPaths.map(child => path.relative(p, child)));
+            glob(globPattern, {dot: showHidden, nodir: true, ignore}, (err, childPaths) => {
+                this.filesMap.set(p, childPaths.reverse().map(child => path.relative(p, child)));
             });
         });
     },


### PR DESCRIPTION
The (excellent) fuzzy search feature supports an option titled "Directories to omit from matching".

However, the parameters are assumed to appear only in the beginning of the path. For instance, `node_modules` is correctly ignored, but only the `node_modules` at the _root_ of your project. If you have multiple projects in your Git repo, each with its own `node_modules`, these are not excluded.

This PR tweaks the arguments to `glob` such that the ignore patterns are passed separately and can match any subdirectory of your project. This way, both `/myproject/node_modules` and `/myproject/mysubproject/node_modules` are correctly ignored.

Additionally, the unnecessary extra globbing against the project root was removed - it turns out `**` can resolve to the project root already - the problem was that you typically weren't seeing file matches from the project root because `glob` returns those at the end of its (potentially very long) array of files that it found, so they were "falling off" the list of the top six matches.

To address this (for now), I simply `reverse()`d the glob array such that the root files appear at the beginning where you would expect to see them.