### PR TITLE
Added support for disabling relative paths. Implement issue #37

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ export default {
         const settings = atom.config.get(PACKAGE_NAME);
         const projectPaths = atom.project.getPaths();
 
-        this._settingsObservers.push(...['hiddenFiles', 'fuzzy', 'projectDependencies'].map(setting =>
+        this._settingsObservers.push(...['hiddenFiles', 'fuzzy', 'relativePaths', 'projectDependencies'].map(setting =>
             atom.config.onDidChange(`${PACKAGE_NAME}.${setting}`, () => {
                 // Just wipe everything and start fresh, relatively expensive but effective
                 this.deactivate();

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -81,7 +81,7 @@ export default class ImportCompletionProvider {
                         };
 
                         if (typeof c === 'string') {
-                            fullCompletion.text = c;
+                            fullCompletion.text = c + 'Hello World';
                         } else {
                             Object.assign(fullCompletion, c);
                         }
@@ -114,6 +114,7 @@ export default class ImportCompletionProvider {
     _findInFiles(editorPath, stringPattern, max, removeExtensionsSetting) {
         const rootDirs = atom.project.getDirectories();
         const containingRoot = rootDirs.find(dir => dir.contains(editorPath));
+		const settings = atom.config.get('autocomplete-js-import');
         const results = [];
 
         if (!containingRoot) {
@@ -139,8 +140,13 @@ export default class ImportCompletionProvider {
                 currFileRelativePath = dropExtensions(currFileRelativePath, removeExtensionsSetting);
 
                 // Show the full path because it lines up with what the user is typing,
-                // but just insert the path relative to the user's current file
-                results.push({text: currFileRelativePath, displayText: rootRelativePath});
+				if(settings.relativePaths.enabled) {
+					// but just insert the path relative to the user's current file
+					results.push({text: currFileRelativePath, displayText: rootRelativePath});
+				} else {
+					// but just insert the path relative to the user's current file
+					results.push({text: rootRelativePath, displayText: rootRelativePath});
+				}
             }
         }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -38,6 +38,17 @@ export default {
             }
         }
     },
+	relativePaths: {
+		type: 'object',
+		title: 'Relative Paths: Use a relative path for imported modules.',
+		properties: {
+			enabled: {
+				title: 'Enabled',
+				type: 'boolean',
+				default: true
+			}
+		}
+    },
     importTypes: {
         type: 'object',
         title: 'Import types for autocompletion',


### PR DESCRIPTION
Hi Daniel,

Awesome Plugin!

Myself and a couple devs from our team installed it today and wished that there was an option to use the project absolute paths instead of relative paths. I implemented this behavior by creating a new option in the settings called relativePaths. It's set to enabled by default which will cause the plugin to continue working as it did before. However, if you disable relative paths the import path will be the project absolute path instead. What do you think?