### PR TITLE
Adds correct result sorting; fixes extension dropping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,9 @@ import path from 'path';
 import glob from 'glob';
 import uniq from 'lodash.uniq';
 
+// TODO: check windows compatibility
+const PATH_DELIMITER = '/';
+
 function readFilePromise(path) {
     return new Promise(resolve => {
         fs.readFile(path, (err, data) => resolve({
@@ -52,7 +55,7 @@ export default {
         const settings = atom.config.get(PACKAGE_NAME);
         const projectPaths = atom.project.getPaths();
 
-        this._settingsObservers.push(...['hiddenFiles', 'fuzzy', 'relativePaths', 'projectDependencies'].map(setting =>
+        this._settingsObservers.push(...['hiddenFiles', 'fuzzy', 'fileRelativePaths', 'projectDependencies'].map(setting =>
             atom.config.onDidChange(`${PACKAGE_NAME}.${setting}`, () => {
                 // Just wipe everything and start fresh, relatively expensive but effective
                 this.deactivate();
@@ -123,7 +126,32 @@ export default {
             const ignore = excludedDirs.map(dir => `${p}/**/${dir}/**`); // like ["/path/to/project/**/node_modules/**", etc.]
 
             glob(globPattern, {dot: showHidden, nodir: true, ignore}, (err, childPaths) => {
-                this.filesMap.set(p, childPaths.reverse().map(child => path.relative(p, child)));
+                this.filesMap.set(
+                    p,
+                    childPaths
+                        // Ensure no empty paths
+                        .filter(Boolean)
+                        // We want shortest paths to appear first when searching so sort based on total path parts
+                        // then alphabetically
+                        // E.G Searching for index.js should appear as so:
+                        // 1. index.js
+                        // 2. some/path/index.js
+                        // 3. some/long/path/index.js
+                        // 4. some/longer/path/index.js
+                        // If we used Glob's output directly, the shortest paths appear last,
+                        // which can cause non unique filenames with short paths to be unsearchable
+                        .sort((a, b) => {
+                            const pathDifference = a.split(PATH_DELIMITER).length - b.split(PATH_DELIMITER).length;
+
+                            if (pathDifference !== 0) {
+                                return pathDifference;
+                            }
+
+                            return a.localeCompare(b);
+                        })
+                        .map(child => path.relative(p, child)
+                    )
+                );
             });
         });
     },

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -66,7 +66,7 @@ export default class ImportCompletionProvider {
 
                 // This is last to give more precedence to package and local file name matches
                 if (settings.fuzzy.enabled) {
-                    results.push(...this._findInFiles(editor.getPath(), packageName, 6));
+                    results.push(...this._findInFiles(editor.getPath(), packageName));
                 }
 
                 return results;
@@ -108,10 +108,9 @@ export default class ImportCompletionProvider {
      * @param  {String} editorPath
      * @param  {String} stringPattern
      * @param  {Number} max
-     * @param  {Array<String>} removeExtensionsSetting - array of extensions to remove from results
      * @return {Array<Object<text: String, displayText: String>>}
      */
-    _findInFiles(editorPath, stringPattern, max) {
+    _findInFiles(editorPath, stringPattern, max = 6) {
         const rootDirs = atom.project.getDirectories();
         const containingRoot = rootDirs.find(dir => dir.contains(editorPath));
 		const settings = atom.config.get('autocomplete-js-import');
@@ -137,14 +136,18 @@ export default class ImportCompletionProvider {
                     currFileRelativePath = './' + currFileRelativePath;
                 }
 
-                currFileRelativePath = dropExtensions(currFileRelativePath, settings.removeExtensions);
-
-                // Show the full path because it lines up with what the user is typing,
+                // Show the full path because it aligns with what the user is typing,
                 if (settings.fileRelativePaths) {
                     // just insert the path relative to the user's current file
-                    results.push({text: currFileRelativePath, displayText: rootRelativePath});
+                    results.push({
+                        text: dropExtensions(currFileRelativePath, settings.removeExtensions),
+                        displayText: rootRelativePath
+                    });
                 } else {
-                    results.push({text: rootRelativePath, displayText: rootRelativePath});
+                    results.push({
+                        text: dropExtensions(rootRelativePath, settings.removeExtensions),
+                        displayText: rootRelativePath
+                    });
                 }
             }
         }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ export default {
     fileRelativePaths: {
         type: 'boolean',
         default: true,
-        title: 'File relative path completion.',
+        title: 'File relative path completion',
         description: 'Upon selecting a match, the path relative to the current file will be inserted.' +
             ' Disabling this results in paths relative to the project'
     },


### PR DESCRIPTION
Previously, the sort of results for fuzzy matching would just be whatever the regular/reverse listing of what the glob module returned. The preferred order is: files with fewer path components should appear first and secondarily sorted alphabetically. This ensures that paths at the root don't disappear from the results, e.g there are max 6 results, a search of `index` finds at least 6 long paths but a path at the root is impossible to search.

Additionally, the new project relative paths feature wasn't adhering to the removeExtensions setting for results.